### PR TITLE
DRO-252: fixed IncomingTranferAccept null check

### DIFF
--- a/src/main/java/com/yandex/money/api/methods/wallet/IncomingTransferAccept.java
+++ b/src/main/java/com/yandex/money/api/methods/wallet/IncomingTransferAccept.java
@@ -61,9 +61,6 @@ public class IncomingTransferAccept extends SimpleResponse {
         switch (status) {
             case REFUSED:
                 switch (error) {
-                    case ILLEGAL_PARAM_PROTECTION_CODE:
-                        checkNotNull(protectionCodeAttemptsAvailable, "protectionCodeAttemptsAvailable");
-                        break;
                     case EXT_ACTION_REQUIRED:
                         checkNotNull(extActionUri, "extActionUri");
                         break;


### PR DESCRIPTION
When protection code is wider than 4 symbols, portal replies with an error but without protection code attempts count.